### PR TITLE
Dashboard theme with Bandcamp colour

### DIFF
--- a/dashboard/.streamlit/config.toml
+++ b/dashboard/.streamlit/config.toml
@@ -1,0 +1,10 @@
+[browser]
+gatherUsageStats = false
+
+[theme]
+base = "light"
+primaryColor = "#3c9aaa"
+
+[client]
+showSidebarNavigation = true
+


### PR DESCRIPTION
Created a `config.toml` file for the dashboard to change theme, including colours. I have included the hex code for the Bandcamp logo colour as the primary colour!

closes #22 