### PR TITLE
fix schema to match erd and loaded data

### DIFF
--- a/schema/schema.sql
+++ b/schema/schema.sql
@@ -19,7 +19,7 @@ CREATE TABLE subscriber (
 CREATE TABLE artist (
     artist_id INT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
     name TEXT NOT NULL,
-    url TEXT UNIQUE NOT NULL
+    url TEXT NOT NULL
 );
 
 CREATE TABLE album (
@@ -33,7 +33,7 @@ CREATE TABLE album (
 CREATE TABLE track (
     track_id INT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
     title TEXT NOT NULL,
-    album_id INT NOT NULL,
+    album_id INT,
     artist_id INT NOT NULL,
     url TEXT UNIQUE NOT NULL,
     FOREIGN KEY (artist_id) REFERENCES artist(artist_id)  


### PR DESCRIPTION
Closes #50 

I've just changed some column constraints in schema.sql to allow for different artists with the same url, and tracks that are not associated with albums. 