### PR TITLE
remove album_id check from get_or_insert_album

### DIFF
--- a/pipeline/load.py
+++ b/pipeline/load.py
@@ -60,7 +60,8 @@ def get_or_insert_country(cursor: DBCursor, country_name: str) -> int:
     otherwise gets the country_id from the table."""
 
     cursor.execute(
-        "SELECT country_id FROM country WHERE country.name = %s", (country_name,)
+        "SELECT country_id FROM country WHERE country.name = %s", (
+            country_name,)
     )
     country_id = cursor.fetchone()
 
@@ -80,9 +81,8 @@ def get_or_insert_album(
     otherwise gets the album_id from the table."""
 
     cursor.execute(
-        "SELECT album_id FROM album WHERE album.title = %s\
-            AND album.artist_id = %s AND album.url = %s",
-        (album_title, artist_id, album_url),
+        "SELECT album_id FROM album WHERE album.title = %s AND album.url = %s",
+        (album_title, album_url),
     )
     album_id = cursor.fetchone()
 

--- a/pipeline/test_load.py
+++ b/pipeline/test_load.py
@@ -115,9 +115,8 @@ def test_get_or_insert_album_existing(mock_get_cursor):
     album_id = get_or_insert_album(mock_cursor, "album_title", 1, "album_url")
     assert album_id == 1
     mock_cursor.execute.assert_called_with(
-        "SELECT album_id FROM album WHERE album.title = %s\
-            AND album.artist_id = %s AND album.url = %s",
-        ("album_title", 1, "album_url"),
+        "SELECT album_id FROM album WHERE album.title = %s AND album.url = %s",
+        ("album_title", "album_url"),
     )
 
 


### PR DESCRIPTION
Resolves #81 
Removal of the artist_id check when determining if an album already exists in the database.