### PR TITLE
Add psycopg2 to requirements

### DIFF
--- a/pipeline/requirements.txt
+++ b/pipeline/requirements.txt
@@ -2,6 +2,7 @@ aiohttp
 asyncio
 bs4
 logging
+psycopg2-binary
 python-dotenv
 pylint
 pytest


### PR DESCRIPTION
Just added `psycopg2-binary` to `pipeline/requirements.txt`. That's it.
Resolves #91 