### PR TITLE
Clean tags #

### DIFF
--- a/pipeline/test_transform.py
+++ b/pipeline/test_transform.py
@@ -150,24 +150,28 @@ def test_transform_sales_data_valid():
 
 
 def test_clean_tags_normal_case():
+    """Tests that tags are properly cleaned in normal cases."""
     tags = [" TagOne ", "##TAGTWO", "#tagthree "]
     expected = ["tagone", "tagtwo", "tagthree"]
     assert clean_tags(tags) == expected
 
 
 def test_clean_tags_empty_list():
+    """Tests that an empty list is handled correctly."""
     tags = []
     expected = []
     assert clean_tags(tags) == expected
 
 
 def test_clean_tags_none():
+    """Tests that 'None' is handled correctly."""
     tags = None
     expected = []
     assert clean_tags(tags) == expected
 
 
 def test_clean_tags_whitespace_only():
+    """Tests that only whitespace is handled correctly."""
     tags = [" ", "   ", " \t "]
     expected = ["", "", ""]
     assert clean_tags(tags) == expected

--- a/pipeline/test_transform.py
+++ b/pipeline/test_transform.py
@@ -150,7 +150,7 @@ def test_transform_sales_data_valid():
 
 
 def test_clean_tags_normal_case():
-    tags = [" TagOne ", "TAGTWO", "tagthree "]
+    tags = [" TagOne ", "##TAGTWO", "#tagthree "]
     expected = ["tagone", "tagtwo", "tagthree"]
     assert clean_tags(tags) == expected
 

--- a/pipeline/transform.py
+++ b/pipeline/transform.py
@@ -59,10 +59,10 @@ def clean_data(sales_data: dict) -> dict:
 
 
 def clean_tags(tags: list[str]) -> list[str]:
-    """Removes leading/trailing whitespace and 'lowercases' a list of tags, returning it."""
+    """Removes leading/trailing whitespace, leading hashtags, and 'lowercases' a list of tags, returning it."""
     if tags is None:
         return []
-    return [tag.strip().lower() for tag in tags]
+    return [tag.lstrip("#").strip().lower() for tag in tags]
 
 
 def transform_sales_data(sales_data: list[dict]) -> list[dict]:


### PR DESCRIPTION
I have improved the transform script to remove any leading hashtags to prevent identical tags like "#pop" and "pop" being considered different tags. This change will result in more accurate and complete data.
Resolves #112.