### PR TITLE
Change SES sender name, other small fixes.

### DIFF
--- a/pdf_report/mailer.py
+++ b/pdf_report/mailer.py
@@ -161,5 +161,4 @@ def send_all_emails() -> None:
 
 if __name__ == "__main__":
 
-    load_dotenv()
     send_all_emails()

--- a/pdf_report/mailer.py
+++ b/pdf_report/mailer.py
@@ -88,7 +88,7 @@ def send_email(
     <html>
     <head></head>
     <body>
-    <h1>Good morning, {recipient_name}!</h1>
+    <h1>Good morning, {recipient_name}.</h1>
     <p>Please see the attached file for your daily generated Bandcamp sales report.</p>
     </body>
     </html>

--- a/pdf_report/mailer.py
+++ b/pdf_report/mailer.py
@@ -89,7 +89,7 @@ def send_email(
     <head></head>
     <body>
     <h1>Good morning, {recipient_name}!</h1>
-    <p>Please see the attached file for your daily generated Bandcamp sales report!</p>
+    <p>Please see the attached file for your daily generated Bandcamp sales report.</p>
     </body>
     </html>
     """
@@ -132,7 +132,7 @@ def send_all_emails() -> None:
         level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
     )
 
-    sender = f"Sender Name <{ENV["SES_SENDER"]}>"
+    sender = f"Apollo Sales Tracker <{ENV["SES_SENDER"]}>"
 
     aws_access_key = str(ENV.get("ACCESS_KEY"))
     aws_secret_access_key = str(ENV.get("SECRET_ACCESS_KEY"))


### PR DESCRIPTION
I have made the following changes in `pdf_report/mailer.py`:

- Replaced the default sender name with something suitable, (resolves #158) feel free to suggest better sender names
- Replaced the exclamation marks in the body and body title of the email with full stops - seems more formal to me
- Removed a redundant `load_dotenv()` call in the main block - it is already being called outside of it